### PR TITLE
Prevent the GID to become 1000 in live builds.

### DIFF
--- a/psychopy_linux_installer
+++ b/psychopy_linux_installer
@@ -1729,7 +1729,7 @@ main() {
     if getent group psychopy >/dev/null; then
         log_message "INFO: Group 'psychopy' already exists."
     else
-        sudo_wrapper groupadd psychopy
+        sudo_wrapper groupadd --system psychopy
         log_message "INFO: Group 'psychopy' created."
     fi
 


### PR DESCRIPTION
In debian 12, when running the installer by live-build in a chroot environnment, the GID of the psychopy group becomes 1000 and makes the final live iso unbootable. I worked around it by removing the psychopy group after the install and adding it back as system group:

groupdel psychopy
groupadd --system psychopy